### PR TITLE
export DOT

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -3085,12 +3085,22 @@ leftBarContentForGraphGenerators m =
                                 [ El.el [ Font.color Colors.red ]
                                     (El.text str)
                                 ]
-                    , El.el [] <|
-                        El.newTabLink []
-                            { url = "data:text/plain;base64," ++ Base64.encode dotFile
-                            , label = El.text "DOT"
-                            }
                     ]
+                , menu
+                    { headerText = "Export"
+                    , isOn = True
+                    , headerItems = []
+                    , toggleMsg = NoOp
+                    , contentItems =
+                        [ El.column [ El.width El.fill, El.spacing 16, El.padding 16 ]
+                            [ El.el [] <|
+                                El.newTabLink []
+                                    { url = "data:text/plain;base64," ++ Base64.encode dotFile
+                                    , label = El.text "DOT"
+                                    }
+                            ]
+                        ]
+                    }
                 ]
             }
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -2,6 +2,7 @@ port module Main exposing (main)
 
 import Algorithms.Dijkstra.API
 import Algorithms.TopologicalSorting.API
+import Base64
 import BoundingBox2d exposing (BoundingBox2d)
 import Browser exposing (Document)
 import Browser.Dom as Dom
@@ -20,6 +21,7 @@ import Element.Keyed
 import Files exposing (Files)
 import Generators.ElmDep as ElmDep
 import Geometry.Svg
+import Graph.DOT
 import Graph.Force as Force exposing (Force)
 import GraphFile as GF exposing (BagId, BagProperties, EdgeId, EdgeProperties, GraphFile, LabelPosition(..), VertexId, VertexProperties)
 import Html as H exposing (Html, div)
@@ -2971,6 +2973,12 @@ leftBarContentForGraphGenerators m =
         listOfFileNames l =
             El.column [ El.padding 10 ]
                 (List.map (\n -> El.el [] (El.text ("- " ++ n))) l)
+
+        dotFile : String
+        dotFile =
+            Graph.DOT.output (\_ -> Nothing)
+                (\_ -> Nothing)
+                (GF.getGraph (Tuple.second (Files.present m.files)))
     in
     El.column [ El.width El.fill ]
         [ --    menu
@@ -3027,8 +3035,6 @@ leftBarContentForGraphGenerators m =
                         { labelText = "Access token (optional)"
                         , labelWidth = 110
                         , inputWidth = 100
-
-                        --, text = m.elmDep.repoNameInput
                         , text = m.elmDep.token
                         , onChange = ElmDep.ChangeToken >> FromElmDep
                         }
@@ -3079,6 +3085,11 @@ leftBarContentForGraphGenerators m =
                                 [ El.el [ Font.color Colors.red ]
                                     (El.text str)
                                 ]
+                    , El.el [] <|
+                        El.newTabLink []
+                            { url = "data:text/plain;base64," ++ Base64.encode dotFile
+                            , label = El.text "DOT"
+                            }
                     ]
                 ]
             }

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -2976,8 +2976,8 @@ leftBarContentForGraphGenerators m =
 
         dotFile : String
         dotFile =
-            Graph.DOT.output (\_ -> Nothing)
-                (\_ -> Nothing)
+            Graph.DOT.output .label
+                .label
                 (GF.getGraph (Tuple.second (Files.present m.files)))
     in
     El.column [ El.width El.fill ]


### PR DESCRIPTION
i thought [using a data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) would be a good way to handle it. i imported `elm/core` and exported [this file.](https://github.com/erkal/kite/files/2923906/elm-core.txt)

is there a better way [than this to get the graph?](https://github.com/erkal/kite/pull/6/files#diff-de84bd170bc37fbce0a7076c0125dd29R2981)

maybe calculating the URL on every render is inefficient. let me know what you think!

<img width="289" alt="screen shot 2019-03-03 at 7 42 45 pm" src="https://user-images.githubusercontent.com/820696/53704651-900f2a80-3dec-11e9-8918-b7c60cd2a9d0.png">
