### PR TITLE
elm package updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: dist/ dist/elm.js dist/index.html
 dist/:
 	mkdir -p $@
 
-dist/elm.js: $(shell find src -type f) package.json
+dist/elm.js: $(shell find src -type f) package.json elm.json
 	$(elm) make src/Main.elm --output $@
 
 dist/index.html: src/index.html

--- a/elm.json
+++ b/elm.json
@@ -5,13 +5,13 @@
     "dependencies": {
         "direct": {
             "NoRedInk/elm-json-decode-pipeline": "1.0.0",
-            "brandly/elm-dot-lang": "1.1.4",
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.2",
+            "brandly/elm-dot-lang": "1.1.5",
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
             "elm/file": "1.0.5",
             "elm/html": "1.0.0",
             "elm/http": "2.0.0",
-            "elm/json": "1.1.2",
+            "elm/json": "1.1.3",
             "elm/parser": "1.1.0",
             "elm/svg": "1.0.1",
             "elm/time": "1.0.0",
@@ -28,20 +28,18 @@
         },
         "indirect": {
             "avh4/elm-fifo": "1.0.4",
-            "elm/bytes": "1.0.7",
+            "elm/bytes": "1.0.8",
             "elm/regex": "1.0.0",
             "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.2",
-            "hecrj/html-parser": "2.3.3",
-            "ianmackenzie/elm-float-extra": "1.0.1",
+            "hecrj/html-parser": "2.4.0",
+            "ianmackenzie/elm-float-extra": "1.1.0",
             "ianmackenzie/elm-interval": "1.0.1",
-            "ianmackenzie/elm-triangular-mesh": "1.0.2"
+            "ianmackenzie/elm-triangular-mesh": "1.0.4"
         }
     },
     "test-dependencies": {
         "direct": {},
-        "indirect": {
-            "elm/random": "1.0.0"
-        }
+        "indirect": {}
     }
 }


### PR DESCRIPTION
hello @erkal! hope you're doing well.

i [fixed my fuzz tests](https://github.com/brandly/elm-dot-lang/pull/11) and found a couple bugs in the process. i'm not sure if anything in this repo uses DOT ports, but parsing a `/` in a name could have cause issues for Kite before now.

i used [`elm-json`](https://github.com/zwilias/elm-json) to do the upgrading by running `$ elm-json upgrade`, which pulled in other available minor updates. `elm-ui` has available minor updates, but it seemed to affect the height of inputs (and maybe other things). instead of messing with it, i just rolled it back to the version we've been on.

`make` didn't do anything after upgrading elm packages, so i made a small change to the `Makefile`.

thanks!